### PR TITLE
[PAPI-88] Liquidity Pool History

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,9 @@ name: Notifications
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
   watch:
-    types: [started, closed, merged]
-
-on:
+    types: [started]
   issues:
     types: [opened, closed]
 

--- a/src/app/models/liquidity-pool-history.ts
+++ b/src/app/models/liquidity-pool-history.ts
@@ -1,4 +1,4 @@
-import { ILiquidityPoolSnapshotHistory } from "./platform-api/responses/liquidity-pools/liquidity-pool.interface";
+import { ILiquidityPoolHistoryResponse } from "./platform-api/responses/liquidity-pools/liquidity-pool-history-response.interface";
 
 export class LiquidityPoolHistory {
   liquidity: any;
@@ -7,15 +7,15 @@ export class LiquidityPoolHistory {
   crsPerSrc: any;
   srcPerCrs: any;
 
-  constructor(history: ILiquidityPoolSnapshotHistory) {
+  constructor(history: ILiquidityPoolHistoryResponse) {
     const liquidity = [];
     const volume = [];
     const staking = [];
     const crsPerSrc = [];
     const srcPerCrs = [];
 
-    history.snapshotHistory.forEach(history => {
-      const time = Date.parse(history.startDate.toString()) / 1000;
+    history.results.forEach(history => {
+      const time = Date.parse(history.timestamp.toString()) / 1000;
 
       liquidity.push({ time, value: history.reserves.usd });
 

--- a/src/app/models/platform-api/responses/liquidity-pools/liquidity-pool-history-response.interface.ts
+++ b/src/app/models/platform-api/responses/liquidity-pools/liquidity-pool-history-response.interface.ts
@@ -1,0 +1,4 @@
+import { IPaging } from '../paging.interface';
+import { ILiquidityPoolSnapshot } from './liquidity-pool.interface';
+
+export interface ILiquidityPoolHistoryResponse extends IPaging<ILiquidityPoolSnapshot> {}

--- a/src/app/models/platform-api/responses/liquidity-pools/liquidity-pool.interface.ts
+++ b/src/app/models/platform-api/responses/liquidity-pools/liquidity-pool.interface.ts
@@ -8,11 +8,6 @@ export interface ILiquidityPoolSummary extends ILiquidityPoolSummaryBase {
   snapshotHistory?: ILiquidityPoolSnapshot[];
 }
 
-export interface ILiquidityPoolSnapshotHistory {
-  address: string,
-  snapshotHistory: ILiquidityPoolSnapshot[];
-}
-
 export interface ILiquidityPoolSummaryBase {
   transactionCount: number;
   transactionFee: number;
@@ -24,8 +19,7 @@ export interface ILiquidityPoolSummaryBase {
 }
 
 export interface ILiquidityPoolSnapshot extends ILiquidityPoolSummaryBase {
-  startDate: Date;
-  endDate: Date;
+  timestamp: Date;
 }
 
 export interface IOhlc {

--- a/src/app/services/api/platform-api.service.ts
+++ b/src/app/services/api/platform-api.service.ts
@@ -1,3 +1,4 @@
+import { ILiquidityPoolHistoryResponse } from '@sharedModels/platform-api/responses/liquidity-pools/liquidity-pool-history-response.interface';
 import { TokensFilter } from '@sharedModels/platform-api/requests/tokens/tokens-filter';
 import { IMarketToken } from '@sharedModels/platform-api/responses/tokens/token.interface';
 import { IAddressMiningPositions } from '@sharedModels/platform-api/responses/wallets/address-mining.interface';
@@ -16,7 +17,7 @@ import { HttpClient } from '@angular/common/http';
 import { RestApiService } from './rest-api.service';
 import { ErrorService } from '@sharedServices/utility/error.service';
 import { Observable } from 'rxjs';
-import { ILiquidityPoolSnapshotHistory, ILiquidityPoolSummary, IMiningPool } from '@sharedModels/platform-api/responses/liquidity-pools/liquidity-pool.interface';
+import { ILiquidityPoolSummary, IMiningPool } from '@sharedModels/platform-api/responses/liquidity-pools/liquidity-pool.interface';
 import { LiquidityPoolsFilter } from '@sharedModels/platform-api/requests/liquidity-pools/liquidity-pool-filter';
 import { TransactionRequest } from '@sharedModels/platform-api/requests/transactions/transactions-filter';
 import { ITransactionReceipt, ITransactionReceipts } from '@sharedModels/platform-api/responses/transactions/transaction.interface';
@@ -165,8 +166,8 @@ export class PlatformApiService extends RestApiService {
     return this.get<ILiquidityPoolsResponse>(`${this.api}/liquidity-pools${query.buildQueryString()}`);
   }
 
-  public getPoolHistory(address: string, timeSpan: string = '1Y'): Observable<ILiquidityPoolSnapshotHistory> {
-    return this.get<ILiquidityPoolSnapshotHistory>(`${this.api}/liquidity-pools/${address}/history?timeSpan=${timeSpan}&candleSpan=Hourly`);
+  public getLiquidityPoolHistory(address: string, request: HistoryFilter): Observable<ILiquidityPoolHistoryResponse> {
+    return this.get<ILiquidityPoolHistoryResponse>(`${this.api}/liquidity-pools/${address}/history${request.buildQueryString()}`);
   }
 
   public startStakingQuote(address: string, payload: IStartStakingRequest): Observable<ITransactionQuote> {

--- a/src/app/services/platform/liquidity-pools.service.ts
+++ b/src/app/services/platform/liquidity-pools.service.ts
@@ -1,5 +1,7 @@
+import { HistoryFilter } from '@sharedModels/platform-api/requests/history-filter';
+import { ILiquidityPoolHistoryResponse } from '@sharedModels/platform-api/responses/liquidity-pools/liquidity-pool-history-response.interface';
 import { ILiquidityPoolsResponse } from '@sharedModels/platform-api/responses/liquidity-pools/liquidity-pools-response.interface';
-import { ILiquidityPoolSummary, ILiquidityPoolSnapshotHistory } from '@sharedModels/platform-api/responses/liquidity-pools/liquidity-pool.interface';
+import { ILiquidityPoolSummary } from '@sharedModels/platform-api/responses/liquidity-pools/liquidity-pool.interface';
 import { PlatformApiService } from '@sharedServices/api/platform-api.service';
 import { Injectable, Injector } from '@angular/core';
 import { Observable } from 'rxjs';
@@ -18,12 +20,12 @@ export class LiquidityPoolsService extends CacheService {
     return this.getItem(address, this._platformApi.getPool(address), cacheOnly);
   }
 
-  getLiquidityPoolHistory(address: string, timeSpan: string = '1Y'): Observable<ILiquidityPoolSnapshotHistory> {
-    return this.getItem(`${address}-history-${timeSpan}`, this._platformApi.getPoolHistory(address, timeSpan));
+  getLiquidityPoolHistory(address: string, request: HistoryFilter): Observable<ILiquidityPoolHistoryResponse> {
+    return this.getItem(`${address}-history-${request.buildQueryString()}`, this._platformApi.getLiquidityPoolHistory(address, request));
   }
 
   getLiquidityPools(request: LiquidityPoolsFilter): Observable<ILiquidityPoolsResponse> {
-    const market: string = this._env.marketAddress;
+    const market = this._env.marketAddress;
 
     if (request.markets.find(m => m === market) === undefined) {
       request.markets.push(market);
@@ -40,7 +42,7 @@ export class LiquidityPoolsService extends CacheService {
     this.refreshItem(`liquidity-pools-${request.buildQueryString()}`);
   }
 
-  refreshPoolHistory(address: string, timeSpan: string = '1Y'): void {
-    this.refreshItem(`${address}-history-${timeSpan}`);
+  refreshPoolHistory(address: string, request: HistoryFilter): void {
+    this.refreshItem(`${address}-history-${request.buildQueryString()}`);
   }
 }

--- a/src/app/views/token/token.component.ts
+++ b/src/app/views/token/token.component.ts
@@ -136,14 +136,14 @@ export class TokenComponent implements OnInit {
       );
   }
 
-  handleChartTypeChange($event) {
+  handleChartTypeChange($event): void {
     this.selectedChart = this.chartOptions.find(options => options.category === $event);
 
     if ($event === 'Line USD') this.chartData = this.tokenHistory.line;
     else if ($event === 'OHLC USD') this.chartData = this.tokenHistory.candle;
   }
 
-  handleChartTimeChange(timeSpan: string) {
+  handleChartTimeChange(timeSpan: string): void {
     let startDate = new Date();
     let endDate = new Date();
     let interval = HistoryInterval.Daily;
@@ -165,11 +165,11 @@ export class TokenComponent implements OnInit {
     this.getTokenHistory().pipe(take(1)).subscribe();
   }
 
-  handleTxOption($event: TransactionView) {
+  handleTxOption($event: TransactionView): void {
     this._sidebar.openSidenav($event);
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.subscription.unsubscribe();
     this.routerSubscription.unsubscribe();
   }


### PR DESCRIPTION
- Modifies the liquidity pool history implementation with an updated Platform API endpoint at `liquidity-pools/{address}/history`.
- Remove unnecessary get liquidity pools call with transaction history filter request building from Market view 